### PR TITLE
Fix windows build error

### DIFF
--- a/netpoll/handle.go
+++ b/netpoll/handle.go
@@ -3,7 +3,6 @@ package netpoll
 import (
 	"net"
 	"os"
-	"syscall"
 )
 
 // filer describes an object that has ability to return os.File.
@@ -89,7 +88,7 @@ func Handle(conn net.Conn, event Event) (*Desc, error) {
 	//
 	// See https://golang.org/pkg/net/#TCPConn.File
 	// See /usr/local/go/src/net/net.go: conn.File()
-	if err = syscall.SetNonblock(desc.fd(), true); err != nil {
+	if err = setNonblock(desc.fd(), true); err != nil {
 		return nil, os.NewSyscallError("setnonblock", err)
 	}
 

--- a/netpoll/handle_stub.go
+++ b/netpoll/handle_stub.go
@@ -1,0 +1,9 @@
+// +build !linux,!darwin,!dragonfly,!freebsd,!netbsd,!openbsd
+
+package netpoll
+
+import "fmt"
+
+func setNonblock(fd int, nonblocking bool) (err error) {
+	return fmt.Errorf("setNonblock is not supported on this operating system")
+}

--- a/netpoll/handle_unix.go
+++ b/netpoll/handle_unix.go
@@ -1,0 +1,9 @@
+// +build linux darwin dragonfly freebsd netbsd openbsd
+
+package netpoll
+
+import "syscall"
+
+func setNonblock(fd int, nonblocking bool) (err error) {
+	return syscall.SetNonblock(fd, nonblocking)
+}


### PR DESCRIPTION
Fix the following error when build on windows:
handle.go:92:38: cannot use desc.fd() (type int) as type syscall.Handle in argument to syscall.SetNonblock